### PR TITLE
ci: add github-action support for utests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,38 @@
+name: Test
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+      - develop
+
+jobs:
+  test:
+    name: Test
+    runs-on: ${{ matrix.platform }}
+    strategy:
+      max-parallel: 4
+      matrix:
+        platform: [ubuntu-latest]
+        python-version: [2.7, 3.5, 3.6, 3.7, pypy3]
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      # https://github.com/marketplace/actions/setup-ffmpeg
+      - name: Install & setup FFMPEG
+        uses: FedericoCarboni/setup-ffmpeg@v1-beta
+      # https://github.com/ymyzk/tox-gh-actions
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install tox tox-gh-actions
+      - name: Test with tox
+        run: tox
+        env:
+          PLATFORM: ${{ matrix.platform }}

--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,19 @@
 # test suite on all supported python versions. To use it, "pip install tox"
 # and then run "tox" from this directory.
 
+[gh-actions]
+python =
+  2.7: py27
+  3.5: py35
+  3.6: py36
+  3.7: py37
+  pypy3: pypy
+
 [tox]
-envlist = py27, py34, py35, py36, py37, pypy
+skipsdist = True
+isolated_build = True
+envlist = py27, py35, py36, py37, pypy
+skip_missing_interpreters = True
 
 [testenv]
 commands = py.test -vv


### PR DESCRIPTION
## Description/Motivation

Perform CI (with pytest+tox) on Github Action:
![image](https://user-images.githubusercontent.com/7001058/105340391-19e16000-5bde-11eb-99c3-ba0c3e3c7d88.png)


## Discussion/Future

- Propose a github action for C(ontinuous) D(elivry) on pypi to release and push pypi package from ffmpeg-python
- Adding some code quality tools/control like flake8, black, pylint, etc ... and perform this check/formatter with Github Action (on PR, commits with precommits, Release, etc ...)